### PR TITLE
Add parameter 'types=place' to geocoding api call in MapController

### DIFF
--- a/web/src/Controller/MapController.php
+++ b/web/src/Controller/MapController.php
@@ -28,7 +28,7 @@ class MapController extends AbstractController
         $cityName = $requestData['cityName'];
 
         // Fetch coordinates from Mapbox Geocoding API
-        $url = "https://api.mapbox.com/geocoding/v5/mapbox.places/{$cityName}.json?access_token={$this->MAP_KEY}";
+        $url = "https://api.mapbox.com/geocoding/v5/mapbox.places/{$cityName}.json?types=place&access_token={$this->MAP_KEY}";
 
         $response = $this->httpClient->request('GET', $url);
         $data = $response->toArray();


### PR DESCRIPTION
This improves search as the api response is more likely to contain a city.

**Example:**
Before this, searching for Jyväskylä returned "Jyväskylä airport". After this change it returns the actual city of Jyväskylä.